### PR TITLE
Zuckergabe pro Flasche mit einer Dezimalstelle

### DIFF
--- a/kleiner-brauhelfer/tababfuellen.cpp
+++ b/kleiner-brauhelfer/tababfuellen.cpp
@@ -174,8 +174,8 @@ void TabAbfuellen::updateValues()
     ui->lblZuckerFlascheEinheit->setVisible(ui->tbZuckerGesamt->value() > 0.0);
 
     value = ui->tbFlasche->value() / bh->sud()->getJungbiermengeAbfuellen();
-    ui->tbSpeisemengeFlasche->setValue((int)(ui->tbSpeisemengeGesamt->value() * value));
-    ui->tbZuckerFlasche->setValue((int)(ui->tbZuckerGesamt->value() * value));
+    ui->tbSpeisemengeFlasche->setValue(ui->tbSpeisemengeGesamt->value() * value);
+    ui->tbZuckerFlasche->setValue(ui->tbZuckerGesamt->value() * value);
     ui->tbGruenschlauchzeitpunkt->setValue(bh->sud()->getGruenschlauchzeitpunkt());
     ui->tbGruenschlauchzeitpunkt->setVisible(ui->cbSchnellgaerprobeAktiv->isChecked());
     ui->lblGruenschlauchzeitpunkt->setVisible(ui->cbSchnellgaerprobeAktiv->isChecked());

--- a/kleiner-brauhelfer/tababfuellen.ui
+++ b/kleiner-brauhelfer/tababfuellen.ui
@@ -1219,6 +1219,9 @@
                <height>0</height>
               </size>
              </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
              <property name="toolTip">
               <string>Benötigte Menge an Zucker pro Flasche.</string>
              </property>

--- a/kleiner-brauhelfer/tababfuellen.ui
+++ b/kleiner-brauhelfer/tababfuellen.ui
@@ -1060,7 +1060,7 @@
             </widget>
            </item>
            <item row="3" column="6">
-            <widget class="SpinBox" name="tbSpeisemengeFlasche">
+            <widget class="DoubleSpinBox" name="tbSpeisemengeFlasche">
              <property name="minimumSize">
               <size>
                <width>50</width>
@@ -1079,8 +1079,11 @@
              <property name="buttonSymbols">
               <enum>QAbstractSpinBox::NoButtons</enum>
              </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
              <property name="maximum">
-              <number>99999</number>
+              <double>99999.899999999994179</double>
              </property>
             </widget>
            </item>
@@ -1212,15 +1215,12 @@
             </widget>
            </item>
            <item row="4" column="6">
-            <widget class="SpinBox" name="tbZuckerFlasche">
+            <widget class="DoubleSpinBox" name="tbZuckerFlasche">
              <property name="minimumSize">
               <size>
                <width>50</width>
                <height>0</height>
               </size>
-             </property>
-             <property name="decimals">
-              <number>1</number>
              </property>
              <property name="toolTip">
               <string>Benötigte Menge an Zucker pro Flasche.</string>
@@ -1234,8 +1234,11 @@
              <property name="buttonSymbols">
               <enum>QAbstractSpinBox::NoButtons</enum>
              </property>
+             <property name="decimals">
+              <number>1</number>
+             </property>
              <property name="maximum">
-              <number>9999</number>
+              <double>99999.899999999994179</double>
              </property>
             </widget>
            </item>


### PR DESCRIPTION
Bei der benötigten Zuckergabe pro Flasche in den Abfülldaten werden bisher keine Dezimalstellen angezeigt. Das ist für eine sinnvolle Dosierung zu ungenau.