### PR TITLE
Fenster-Titel wie geöffente Datei in Inkscape oder LibreOffice für den geladenen Sud

### DIFF
--- a/kleiner-brauhelfer/mainwindow.cpp
+++ b/kleiner-brauhelfer/mainwindow.cpp
@@ -385,9 +385,9 @@ void MainWindow::databaseModified()
     QString title;
     if (modified)
         title = "* ";
-    title += QCoreApplication::applicationName() + " v" + QCoreApplication::applicationVersion();
     if (bh->sud()->isLoaded())
-        title += " - " + bh->sud()->getSudname();
+        title += bh->sud()->getSudname() + " - ";
+    title += QCoreApplication::applicationName() + " v" + QCoreApplication::applicationVersion();
     setWindowTitle(title);
     ui->actionSpeichern->setEnabled(modified);
     ui->actionVerwerfen->setEnabled(modified);


### PR DESCRIPTION
Der geladene Sud entspricht einer geladenen Datei in anderen Programmen wie Inkscape oder LibreOffice. Dort befindet sich der Dateiname vorne im Fenster-Titel und lässt den Nutzer schneller Informationen erfassen.
Die Änderung zieht das für den Brauhelfer nach.
