### PR TITLE
Add button to run workflows manually

### DIFF
--- a/.github/workflows/linux64.yml
+++ b/.github/workflows/linux64.yml
@@ -1,6 +1,9 @@
 name: linux64
 
 on:
+  workflow_dispatch:
+      tags:
+        description: 'Test workflow'
   push:
     branches: 
       - master

--- a/.github/workflows/linux64.yml
+++ b/.github/workflows/linux64.yml
@@ -2,8 +2,9 @@ name: linux64
 
 on:
   workflow_dispatch:
+    inputs:
       tags:
-        description: 'Test workflow'
+        description: 'Test workflow on branch'
   push:
     branches: 
       - master

--- a/.github/workflows/linux64.yml
+++ b/.github/workflows/linux64.yml
@@ -2,9 +2,6 @@ name: linux64
 
 on:
   workflow_dispatch:
-    inputs:
-      tags:
-        description: 'Test workflow on branch'
   push:
     branches: 
       - master

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -1,6 +1,7 @@
 name: macOS
 
 on:
+  workflow_dispatch:
   push:
     branches: 
       - master

--- a/.github/workflows/win64.yml
+++ b/.github/workflows/win64.yml
@@ -1,6 +1,7 @@
 name: win64
 
 on:
+  workflow_dispatch:
   push:
     branches: 
       - master


### PR DESCRIPTION
Aktuell triggert der GitHub-Workflow nur auf einen Push auf den Master-Branch.
Mit dem `workflow_dispatch`-Event erhält der Workflow einen "Run Workflow"-Knopf mit dem sich ein Workflow manuell starten lässt.

> ![image](https://user-images.githubusercontent.com/44663346/147247190-4ab92cbb-42a7-44ec-bea8-4b8afd6b169a.png)

### Vorteile

Dabei kann der Branch frei gewählt werden auf dem der Workflow läuft. Das bringt zwei wesentliche Vorteile mit sich:

- Es entstehen Binaries für einen Branch den dann auch alle anderen herunterladen können.
- Spart das aufsetzen von mehreren Build-Umgebungen für Tests auf Linux, Mac und Windows während der Entwicklung.

> Artifacts für einen Workflow bleiben 90 Tage zum Download bereit.
> ![image](https://user-images.githubusercontent.com/44663346/147247421-4074255b-4f6b-42f7-9414-8d0e46a9c5e5.png)
