### PR TITLE
Fix issues when using Qt6

### DIFF
--- a/kleiner-brauhelfer/dialogs/dlgdatenbank.cpp
+++ b/kleiner-brauhelfer/dialogs/dlgdatenbank.cpp
@@ -92,7 +92,7 @@ void DlgDatenbank::restoreView()
 
 void DlgDatenbank::sudLoaded()
 {
-    on_comboBoxSud_currentIndexChanged(ui->comboBoxSud->currentText());
+    on_comboBoxSud_currentTextChanged(ui->comboBoxSud->currentText());
 }
 
 void DlgDatenbank::updateValues()
@@ -101,7 +101,7 @@ void DlgDatenbank::updateValues()
     ui->tbDatenbankVersion->setText(QString::number(bh->databaseVersion()));
 }
 
-void DlgDatenbank::on_comboBox_currentIndexChanged(const QString &table)
+void DlgDatenbank::on_comboBox_currentTextChanged(const QString &table)
 {
     SqlTableModel* model = nullptr;
     if (table == bh->modelAnhang()->tableName())
@@ -160,7 +160,7 @@ void DlgDatenbank::on_comboBox_currentIndexChanged(const QString &table)
     }
 }
 
-void DlgDatenbank::on_comboBoxSud_currentIndexChanged(const QString &table)
+void DlgDatenbank::on_comboBoxSud_currentTextChanged(const QString &table)
 {
     ProxyModel* model = nullptr;
     if (table == bh->modelAnhang()->tableName())

--- a/kleiner-brauhelfer/dialogs/dlgdatenbank.h
+++ b/kleiner-brauhelfer/dialogs/dlgdatenbank.h
@@ -23,8 +23,8 @@ public:
 private slots:
     void sudLoaded();
     void updateValues();
-    void on_comboBox_currentIndexChanged(const QString &table);
-    void on_comboBoxSud_currentIndexChanged(const QString &table);
+    void on_comboBox_currentTextChanged(const QString &table);
+    void on_comboBoxSud_currentTextChanged(const QString &table);
     void tableView_selectionChanged();
 
 private:

--- a/kleiner-brauhelfer/dialogs/dlgrestextrakt.cpp
+++ b/kleiner-brauhelfer/dialogs/dlgrestextrakt.cpp
@@ -237,7 +237,7 @@ void DlgRestextrakt::on_tbKorrekturFaktor_valueChanged(double value)
     }
 }
 
-void DlgRestextrakt::on_comboBox_FormelBrixPlato_currentIndexChanged(const QString &)
+void DlgRestextrakt::on_comboBox_FormelBrixPlato_currentTextChanged(const QString &)
 {
     if (ui->comboBox_FormelBrixPlato->hasFocus())
     {

--- a/kleiner-brauhelfer/dialogs/dlgrestextrakt.h
+++ b/kleiner-brauhelfer/dialogs/dlgrestextrakt.h
@@ -30,7 +30,7 @@ private slots:
     void on_tbEichtemp_valueChanged(double value);
     void on_tbBrix_valueChanged(double);
     void on_cbEinheit_activated(int);
-    void on_comboBox_FormelBrixPlato_currentIndexChanged(const QString &value);
+    void on_comboBox_FormelBrixPlato_currentTextChanged(const QString &value);
     void on_tbKorrekturFaktor_valueChanged(double value);
     void on_btnKorrekturFaktorDefault_clicked();
     void on_tbTempRefraktometer_valueChanged(double value);

--- a/kleiner-brauhelfer/tabrezept.cpp
+++ b/kleiner-brauhelfer/tabrezept.cpp
@@ -1397,7 +1397,7 @@ void TabRezept::on_tbSudname_textChanged(const QString &value)
         bh->sud()->setSudname(value);
 }
 
-void TabRezept::on_cbKategorie_currentIndexChanged(const QString &value)
+void TabRezept::on_cbKategorie_currentTextChanged(const QString &value)
 {
     if (ui->cbKategorie->hasFocus())
         bh->sud()->setKategorie(value);
@@ -1412,7 +1412,7 @@ void TabRezept::on_btnKategorienVerwalten_clicked()
     dlg.exec();
 }
 
-void TabRezept::on_cbAnlage_currentIndexChanged(const QString &value)
+void TabRezept::on_cbAnlage_currentTextChanged(const QString &value)
 {
     if (ui->cbAnlage->hasFocus())
         bh->sud()->setAnlage(value);
@@ -1428,7 +1428,7 @@ void TabRezept::on_btnVerdampfungsrate_clicked()
     bh->sud()->setVerdampfungsrate(bh->sud()->getAnlageData(ModelAusruestung::ColVerdampfungsrate).toDouble());
 }
 
-void TabRezept::on_cbWasserProfil_currentIndexChanged(const QString &value)
+void TabRezept::on_cbWasserProfil_currentTextChanged(const QString &value)
 {
     if (ui->cbWasserProfil->hasFocus())
         bh->sud()->setWasserprofil(value);

--- a/kleiner-brauhelfer/tabrezept.cpp
+++ b/kleiner-brauhelfer/tabrezept.cpp
@@ -5,6 +5,7 @@
 #include <QGraphicsSvgItem>
 #include <QStandardItemModel>
 #include <QMessageBox>
+#include <QScrollBar>
 #include "settings.h"
 #include "mainwindow.h"
 #include "model/textdelegate.h"

--- a/kleiner-brauhelfer/tabrezept.h
+++ b/kleiner-brauhelfer/tabrezept.h
@@ -69,12 +69,12 @@ private slots:
     void on_btnNeuerAnhang_clicked();
 
     void on_tbSudname_textChanged(const QString &value);
-    void on_cbKategorie_currentIndexChanged(const QString &value);
+    void on_cbKategorie_currentTextChanged(const QString &value);
     void on_btnKategorienVerwalten_clicked();
-    void on_cbAnlage_currentIndexChanged(const QString &value);
+    void on_cbAnlage_currentTextChanged(const QString &value);
     void on_btnSudhausausbeute_clicked();
     void on_btnVerdampfungsrate_clicked();
-    void on_cbWasserProfil_currentIndexChanged(const QString &value);
+    void on_cbWasserProfil_currentTextChanged(const QString &value);
     void on_btnWasserProfil_clicked();
 
     void on_btnTagNeu_clicked();

--- a/kleiner-brauhelfer/widgets/wdgwebvieweditable.cpp
+++ b/kleiner-brauhelfer/widgets/wdgwebvieweditable.cpp
@@ -214,7 +214,7 @@ void WdgWebViewEditable::on_cbEditMode_clicked(bool checked)
     ui->splitterEditmode->setSizes({1, checked ? 1 : 0});
 }
 
-void WdgWebViewEditable::on_cbTemplateAuswahl_currentIndexChanged(const QString &fileName)
+void WdgWebViewEditable::on_cbTemplateAuswahl_currentTextChanged(const QString &fileName)
 {
     Q_UNUSED(fileName)
     updateEditMode();

--- a/kleiner-brauhelfer/widgets/wdgwebvieweditable.h
+++ b/kleiner-brauhelfer/widgets/wdgwebvieweditable.h
@@ -37,7 +37,7 @@ private slots:
     void printDocument(QPrinter *printer);
   #endif
     void on_cbEditMode_clicked(bool checked);
-    void on_cbTemplateAuswahl_currentIndexChanged(const QString &fileName);
+    void on_cbTemplateAuswahl_currentTextChanged(const QString &fileName);
     void on_btnSaveTemplate_clicked();
     void on_btnRestoreTemplate_clicked();
     void on_tbTemplate_textChanged();


### PR DESCRIPTION
I tried to compile the software with Qt 6.2.4 and got a few issues:
- add one missing include
- replace deprecated function (see https://doc.qt.io/qt-5/qcombobox-obsolete.html)

I think the changes are backwards compatible, so they should also work with the officially used Qt5.
