### PR TITLE
add deployment information for Arch Linux related distros

### DIFF
--- a/deployment/arch-linux/PKGBUILD
+++ b/deployment/arch-linux/PKGBUILD
@@ -1,0 +1,37 @@
+# Maintainer: bitwave <aur [aT] oomlu {d.0t} de>
+# Contributor: jkoch < 	johannes [aTTTT] ortsraum {d00t} de>
+# Contributor: Daniel Dietrich <shaddow2k@@gmail..com>
+pkgname=kleiner-brauhelfer
+pkgver=2.5.0
+pkgrel=1
+pkgdesc="A Qt-based tool for hobby brewer to calculate and manage the beer brewing process."
+arch=("i686" "x86_64")
+url="https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2"
+license=('GPL3')
+depends=('qt5-webengine' 'qt5-charts' 'qt5-svg')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/kleiner-brauhelfer/$pkgname-2/archive/v$pkgver.tar.gz"
+        kleiner-brauhelfer.desktop)
+
+build() {
+  pwd
+  cd "$pkgname-2-$pkgver"
+
+  qmake-qt5 kleiner-brauhelfer-2.pro
+  make
+}
+
+package() {
+  cd "$pkgname-2-$pkgver"
+  
+  install -d "$pkgdir/usr/bin"
+  install -m755 -D "bin/kleiner-brauhelfer-2" "$pkgdir/usr/bin"
+
+  install -d "$pkgdir/usr/share/pixmaps"
+  install -m644 -D "deployment/kleiner-brauhelfer-2.svg" "$pkgdir/usr/share/pixmaps"
+
+  install -d "$pkgdir/usr/share/applications"
+  install -m644 -D "$srcdir/kleiner-brauhelfer.desktop" "$pkgdir/usr/share/applications"
+}
+
+sha256sums=('025d833802d542bb1271e6c9293bca448b134b0f8e3cf44b0cf06e6a43b1077c'
+            '09e1a7e1af560c422f2df3a822ce11143827c6dcd1e9083b22c17660e583f231')

--- a/deployment/arch-linux/PKGBUILD
+++ b/deployment/arch-linux/PKGBUILD
@@ -10,7 +10,7 @@ url="https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2"
 license=('GPL3')
 depends=('qt5-webengine' 'qt5-charts' 'qt5-svg')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/kleiner-brauhelfer/$pkgname-2/archive/v$pkgver.tar.gz"
-        kleiner-brauhelfer.desktop)
+        kleiner-brauhelfer-2.desktop)
 
 build() {
   pwd
@@ -30,8 +30,8 @@ package() {
   install -m644 -D "deployment/kleiner-brauhelfer-2.svg" "$pkgdir/usr/share/pixmaps"
 
   install -d "$pkgdir/usr/share/applications"
-  install -m644 -D "$srcdir/kleiner-brauhelfer.desktop" "$pkgdir/usr/share/applications"
+  install -m644 -D "$srcdir/kleiner-brauhelfer-2.desktop" "$pkgdir/usr/share/applications"
 }
 
 sha256sums=('025d833802d542bb1271e6c9293bca448b134b0f8e3cf44b0cf06e6a43b1077c'
-            '09e1a7e1af560c422f2df3a822ce11143827c6dcd1e9083b22c17660e583f231')
+            '9c62221a95a262d50f3a2bf4e497f1ac98f998c1d9e8ee1118fba135730884cc')

--- a/deployment/arch-linux/README.md
+++ b/deployment/arch-linux/README.md
@@ -5,7 +5,7 @@ This deployment method does not build the kleiner-brauhelfer-2 application for b
 
 Instead, it allows the enduser very easily to build and install kleiner-brauhelfer-2 by himself. The method uses [makepkg](https://wiki.archlinux.org/title/makepkg) to build and install the Arch-Linux package. 
 
-The information for building the package is contained in the two files **PKGBUILD** and **kleiner-brauhelfer-2.desktop** stored and stored in the [Arch-Linux User Repository](https://aur.archlinux.org/packages/kleiner-brauhelfer), also called AUR. 
+The information for building the package is contained in the two files **PKGBUILD** and **kleiner-brauhelfer-2.desktop**. They are stored in the [Arch-Linux User Repository](https://aur.archlinux.org/packages/kleiner-brauhelfer), also called AUR. 
 
 ## Prerequisit:
 

--- a/deployment/arch-linux/README.md
+++ b/deployment/arch-linux/README.md
@@ -5,7 +5,7 @@ This deployment method does not build the kleiner-brauhelfer-2 application for b
 
 Instead, it allows the enduser very easily to build and install kleiner-brauhelfer-2 by himself. The method uses [makepkg](https://wiki.archlinux.org/title/makepkg) to build and install the Arch-Linux package. 
 
-The information for building the package is contained in the two files *PKGBUILD* and *kleiner-brauhelfer-2.desktop* stored and stored in the [Arch-Linux User Repository](https://aur.archlinux.org/packages/kleiner-brauhelfer), also called AUR. 
+The information for building the package is contained in the two files **PKGBUILD** and **kleiner-brauhelfer-2.desktop** stored and stored in the [Arch-Linux User Repository](https://aur.archlinux.org/packages/kleiner-brauhelfer), also called AUR. 
 
 ## Prerequisit:
 
@@ -28,7 +28,7 @@ git clone https://aur.archlinux.org/kleiner-brauhelfer.git
 cd kleiner-brauhelfer
 makepkg -s
 ```
-Proceed to Install the Package.
+Proceed to [Install the Package](#install-the-package).
 
 If you want to build and install a different version:
 - mkdir kleiner-brauhelfer-2.build
@@ -51,12 +51,15 @@ Have a lot of fun with kleiner-brauhelfer-2
 
 ## Upgrade the Package 
 
-If you still auf the local build directory (assumed: kb-builddir) from an previous installation:
+If you still have access to the local build directory from an previous installation:
+
+Execute following commands in a shell:
+
 ```bash
-cd kb-builddir
+cd kleiner-brauhelfer #(the directory of the previous installation)
 git pull
 makepkg -s
 makepkg -i
 ```
 
-If the directory was deleted, follow the instructions *Build the Installation Packag* and *Install the Packate*.
+If the directory was deleted, follow the instructions [Build the Installation Package](#building-the-installation-package) and [Install the Package](#install-the-package)

--- a/deployment/arch-linux/README.md
+++ b/deployment/arch-linux/README.md
@@ -3,7 +3,7 @@ Arch-Linux and followers do not support the debian package format, they have the
 
 This deployment method does not build the kleiner-brauhelfer-2 application for being downloaded from github.  
 
-Instead, it allows the enduser very easily to build and install kleiner-brauhelfer-2 by himself. The method uses [makepkg](https://wiki.archlinux.org/title/makepkg) to build and install the Arch-Linux package. 
+Instead, it allows the enduser very easily to build and install kleiner-brauhelfer-2 by himself. This method uses [makepkg](https://wiki.archlinux.org/title/makepkg) to download the sources from a specific kleiner-brauhelfer-2 version at github, build the executable and create and install the Arch-Linux package. 
 
 The information for building the package is contained in the two files **PKGBUILD** and **kleiner-brauhelfer-2.desktop**. They are stored in the [Arch-Linux User Repository](https://aur.archlinux.org/packages/kleiner-brauhelfer), also called AUR. 
 

--- a/deployment/arch-linux/README.md
+++ b/deployment/arch-linux/README.md
@@ -1,0 +1,62 @@
+# Deployment of kleiner-brauhelfer-2 on Arch-Linux
+Arch-Linux and followers do not support the debian package format, they have their own.
+
+This deployment method does not build the kleiner-brauhelfer-2 application for being downloaded from github.  
+
+Instead, it allows the enduser very easily to build and install kleiner-brauhelfer-2 by himself. The method uses [makepkg](https://wiki.archlinux.org/title/makepkg) to build and install the Arch-Linux package. 
+
+The information for building the package is contained in the two files *PKGBUILD* and *kleiner-brauhelfer-2.desktop* stored and stored in the [Arch-Linux User Repository](https://aur.archlinux.org/packages/kleiner-brauhelfer), also called AUR. 
+
+## Prerequisit:
+
+Install the needed tools by executing in a terminal:
+
+```bash
+pamac install git base-devel
+```
+
+## Building the Installation Package
+
+Open the package information of [kleiner-brauhelfer at arch-linux.org](https://aur.archlinux.org/packages/kleiner-brauhelfer):
+
+Check the version of kleiner-brauhelfer-2 being created fit's your need.
+
+Execute following commands in the shell: 
+
+```bash
+git clone https://aur.archlinux.org/kleiner-brauhelfer.git
+cd kleiner-brauhelfer
+makepkg -s
+```
+Proceed to Install the Package.
+
+If you want to build and install a different version:
+- mkdir kleiner-brauhelfer-2.build
+- copy PKGBUILD and kleiner-brauhelfer-2.desktop from  deployment/arch-linux directory on github to the working directory
+- cd working directory
+- makepkg -s 
+
+
+## Install the Package
+
+Install the package by executing in a shell:
+
+```bash
+makepkg -i
+```
+
+## Enjoy
+
+Have a lot of fun with kleiner-brauhelfer-2
+
+## Upgrade the Package 
+
+If you still auf the local build directory (assumed: kb-builddir) from an previous installation:
+```bash
+cd kb-builddir
+git pull
+makepkg -s
+makepkg -i
+```
+
+If the directory was deleted, follow the instructions *Build the Installation Packag* and *Install the Packate*.

--- a/deployment/arch-linux/kleiner-brauhelfer-2.desktop
+++ b/deployment/arch-linux/kleiner-brauhelfer-2.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Encoding=UTF-8
-Name=kleiner-brauhelfer
+Name=kleiner-brauhelfer-2
 Comment=Program to calculate and manage beer brewing
 Comment[de]=Ein Programm zum Berechnen und Verwalten von Biersuden
 Exec=kleiner-brauhelfer-2

--- a/deployment/arch-linux/kleiner-brauhelfer.desktop
+++ b/deployment/arch-linux/kleiner-brauhelfer.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Encoding=UTF-8
+Name=kleiner-brauhelfer
+Comment=Program to calculate and manage beer brewing
+Comment[de]=Ein Programm zum Berechnen und Verwalten von Biersuden
+Exec=kleiner-brauhelfer-2
+Icon=kleiner-brauhelfer-2
+Categories=Office;
+StartupWMClass=kleiner-brauhelfer-2
+


### PR DESCRIPTION
Hi All,

first, this is my first try to contribute to an github project. So I would realy appreciate any hints for doing things better.

second: I hope it is ok to communicate in English.

Now to the pull request: 

This change adds three files in an additional directory to the project. 
The directory, PKGBUILD and kleiner-brauhelfer-2.desktop were already part of the first version (kleiner-brauhelfer), but were not copied/migrated to version 2.

An README.md is also provided which documents how to build the Arch Linux package of kbh2. I am not quite sure how to link this information into the existing documentation - maybe you can give me a hint or you can put the link into the existing docs.

If you are not familar with Arch Linux speciality: Arch does not support installing Debian packages. The alternative used method in those cases is download the sources from github, build the software from scratch, create an installation package and install it. It is also used for getting other more common packages to this platform like Google Chrome, VisualCode.

When creating new version of kbh you can send me an E-Mail, so I can contribute an update to PGKBUILD to cover the new version.

Have fun!

regards

Peter