### PR TITLE
Einmaischvolumen bei beerXML Export abspeichern

### DIFF
--- a/kleiner-brauhelfer-core/importexport.cpp
+++ b/kleiner-brauhelfer-core/importexport.cpp
@@ -1809,7 +1809,7 @@ QByteArray ImportExport::exportBeerXml(Brauhelfer* bh, int sudRow)
         switch (typ)
         {
         case Brauhelfer::RastTyp::Einmaischen:
-            text = doc.createTextNode("Temperature");
+            text = doc.createTextNode("Infusion");
             break;
         case Brauhelfer::RastTyp::Temperatur:
             text = doc.createTextNode("Temperature");
@@ -1834,7 +1834,7 @@ QByteArray ImportExport::exportBeerXml(Brauhelfer* bh, int sudRow)
         element.appendChild(text);
         Anteil.appendChild(element);
 
-        if (typ == Brauhelfer::RastTyp::Infusion)
+        if (typ == Brauhelfer::RastTyp::Infusion || typ == Brauhelfer::RastTyp::Einmaischen)
         {
             element = doc.createElement("INFUSE_AMOUNT");
             text = doc.createTextNode(QString::number(model.data(row, ModelRasten::ColMenge).toDouble(), 'f', 1));


### PR DESCRIPTION
Beim Experimentieren mit dem Grainfather ist mir aufgefallen, dass die Wassermenge beim Einmaischen nicht im beerXML Export landet. Dadurch Stimmen die Angaben für Haupt- und Nachguss nicht.

Dieser Patch definiert beim beerXML Export den Einmaischvorgang als `Infusion` und speichert das Einmaischvolumen im Unterknoten `INFUSE_AMOUNT`.