### PR TITLE
Add gentoo ebuild

### DIFF
--- a/deployment/gentoo-linux/README.md
+++ b/deployment/gentoo-linux/README.md
@@ -2,17 +2,24 @@
 1. Configure a local overlay
 Run:
 
-    eselect repository create local
+````
+eselect repository create local
+````
 
 2. Copy ebuild to local overlay
 
-    mkdir -p /var/db/repos/local/sci-chemistry/kleiner-brauhelfer/
-    cp deployment/gentoo-linux/*.ebuild /var/db/repos/local/sci-chemistry/kleiner-brauhelfer/
+````
+mkdir -p /var/db/repos/local/sci-chemistry/kleiner-brauhelfer/
+cp deployment/gentoo-linux/*.ebuild /var/db/repos/local/sci-chemistry/kleiner-brauhelfer/
+````
 
 3. Create manifests
 
-    ebuild /var/db/repos/local/sci-chemistry/kleiner-brauhelfer/*.ebuild digest
-
+````
+ ebuild /var/db/repos/local/sci-chemistry/kleiner-brauhelfer/*.ebuild digest
+````
 3. Install
-
-    emerge -av sci-chemistry/kleiner-brauhelfer
+ 
+````
+emerge -av sci-chemistry/kleiner-brauhelfer
+````

--- a/deployment/gentoo-linux/README.md
+++ b/deployment/gentoo-linux/README.md
@@ -1,0 +1,18 @@
+# Deployment of kleiner-brauhelfer-2 on Gentoo Linux
+1. Configure a local overlay
+Run:
+
+    eselect repository create local
+
+2. Copy ebuild to local overlay
+
+    mkdir -p /var/db/repos/local/sci-chemistry/kleiner-brauhelfer/
+    cp deployment/gentoo-linux/*.ebuild /var/db/repos/local/sci-chemistry/kleiner-brauhelfer/
+
+3. Create manifests
+
+    ebuild /var/db/repos/local/sci-chemistry/kleiner-brauhelfer/*.ebuild digest
+
+3. Install
+
+    emerge -av sci-chemistry/kleiner-brauhelfer

--- a/deployment/gentoo-linux/README.md
+++ b/deployment/gentoo-linux/README.md
@@ -1,6 +1,5 @@
 # Deployment of kleiner-brauhelfer-2 on Gentoo Linux
 1. Configure a local overlay
-Run:
 
 ````
 eselect repository create local

--- a/deployment/gentoo-linux/kleiner-brauhelfer-2.6.1.ebuild
+++ b/deployment/gentoo-linux/kleiner-brauhelfer-2.6.1.ebuild
@@ -1,7 +1,7 @@
 EAPI=7
 inherit desktop qmake-utils
 DESCRIPTION="Der kleine Brauhelfer ist ein Hilfsprogramm für Hobbybrauer zum Erstellen und Verwalten von Biersuden"
-HOMEPAGE="https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2"
+HOMEPAGE="http://kleiner-brauhelfer.github.io"
 
 if [[ ${PV} != 9999 ]]; then
 	SRC_URI="https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
@@ -16,8 +16,7 @@ KEYWORDS="amd64 x86"
 IUSE=""
 
 DEPEND="
-	dev-qt/qtwebengine:6
-	dev-qt/qtcharts:6
+	dev-qt/qtwebengine:6	
 	dev-qt/qtsvg:6
 "
 

--- a/deployment/gentoo-linux/kleiner-brauhelfer-2.6.1.ebuild
+++ b/deployment/gentoo-linux/kleiner-brauhelfer-2.6.1.ebuild
@@ -1,0 +1,44 @@
+EAPI=7
+inherit desktop qmake-utils
+DESCRIPTION="Der kleine Brauhelfer ist ein Hilfsprogramm für Hobbybrauer zum Erstellen und Verwalten von Biersuden"
+HOMEPAGE="https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2"
+
+if [[ ${PV} != 9999 ]]; then
+	SRC_URI="https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+else
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2.git"
+fi
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="amd64 x86"
+IUSE=""
+
+DEPEND="
+	dev-qt/qtwebengine:6
+	dev-qt/qtcharts:6
+	dev-qt/qtsvg:6
+"
+
+RDEPEND="${DEPEND}"
+BDEPEND="${DEPEND}"
+
+
+S="${WORKDIR}/${PN}-2-${PV}"
+
+src_unpack() {
+	unpack "${A}"
+	cd "${S}"
+}
+
+src_configure() {
+	eqmake6 kleiner-brauhelfer-2.pro PREFIX="${EPREFIX}"/usr INSTALL_ROOT=.
+}
+
+src_install() {
+	doicon "${S}/deployment/kleiner-brauhelfer-2.svg"
+	domenu "${S}/deployment/linux/64bit/deb/kleiner-brauhelfer-2.desktop"
+	dobin "${S}/bin/kleiner-brauhelfer-2"
+}
+

--- a/deployment/gentoo-linux/kleiner-brauhelfer-9999.ebuild
+++ b/deployment/gentoo-linux/kleiner-brauhelfer-9999.ebuild
@@ -1,0 +1,42 @@
+EAPI=7
+inherit desktop qmake-utils
+DESCRIPTION="Der kleine Brauhelfer ist ein Hilfsprogramm für Hobbybrauer zum Erstellen und Verwalten von Biersuden"
+HOMEPAGE="http://kleiner-brauhelfer.github.io"
+
+if [[ ${PV} != 9999 ]]; then
+	SRC_URI="https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2/archive/refs/tags/v${PV}.tar.gz -> ${P}.tar.gz"
+else
+	inherit git-r3
+	EGIT_REPO_URI="https://github.com/kleiner-brauhelfer/kleiner-brauhelfer-2.git"
+fi
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="amd64 x86"
+IUSE=""
+
+DEPEND="
+	dev-qt/qtwebengine:6	
+	dev-qt/qtsvg:6
+"
+
+RDEPEND="${DEPEND}"
+BDEPEND="${DEPEND}"
+
+
+S="${WORKDIR}/${PN}-2-${PV}"
+
+src_unpack() {
+	unpack "${A}"
+	cd "${S}"
+}
+
+src_configure() {
+	eqmake6 kleiner-brauhelfer-2.pro PREFIX="${EPREFIX}"/usr INSTALL_ROOT=.
+}
+
+src_install() {
+	doicon "${S}/deployment/kleiner-brauhelfer-2.svg"
+	domenu "${S}/deployment/linux/64bit/deb/kleiner-brauhelfer-2.desktop"
+	dobin "${S}/bin/kleiner-brauhelfer-2"
+}


### PR DESCRIPTION
This PR adds a gentoo ebuild file and instructions how to use the ebuild on gentoo linux.
Whenever a new version of kleiner-brauhelfer is released, the ebuild-file needs to be renamed according to the version.