### PR TITLE
Implement basic CMake based build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 build*/
-*pro.user*
+*.user
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION  3.18.0)
+
+# Define base project and version information
+project(kleiner-brauhelfer-2 VERSION 2.0.0 LANGUAGES C CXX)
+
+# Globally disable static linkage for Qt6
+set(Qt6_STATIC OFF CACHE BOOL "" FORCE)
+
+# We require the C++ 11 standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Add sub-projects, the ordering here matters!
+add_subdirectory(kleiner-brauhelfer-core)
+add_subdirectory(kleiner-brauhelfer)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,6 @@
-cmake_minimum_required(VERSION  3.18.0)
+cmake_minimum_required(VERSION 3.16)
 
-# Define base project and version information
-project(kleiner-brauhelfer-2 VERSION 2.0.0 LANGUAGES C CXX)
+project(kleiner-brauhelfer-2)
 
-# Globally disable static linkage for Qt6
-set(Qt6_STATIC OFF CACHE BOOL "" FORCE)
-
-# We require the C++ 11 standard
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-# Add sub-projects, the ordering here matters!
 add_subdirectory(kleiner-brauhelfer-core)
 add_subdirectory(kleiner-brauhelfer)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,25 @@
+{
+  "version": 10,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 18,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "release@kbh",
+      "description": "Release Build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/release@kbh",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "build-release@kbh",
+      "configurePreset": "release@kbh"
+    }
+  ]
+}

--- a/README.CMake.md
+++ b/README.CMake.md
@@ -1,0 +1,47 @@
+# Transition to CMake Build System
+
+As Qt seem to pick CMake as the successor of QMake, it is possible to build this project
+with CMake.
+[https://doc.qt.io/qt-6/qt6-buildsystem.html](https://doc.qt.io/qt-6/qt6-buildsystem.html)
+
+There are two possiblities on how to use CMake for building the project,
+with presets or manually.
+
+
+## Requirements
+The CMake based build system requires additional external build tools on top of Qt6.
+So install them for instance with:
+```
+# Debian/Ubuntu
+sudo apt-get install -y \
+    cmake \
+    ninja
+    
+
+# Arch Linux
+sudo pacman -Syy \
+    cmake \
+    ninja
+    
+    ...
+```
+
+
+## Build with Presets
+```shell
+    cmake --preset release@kbh
+    cmake --build --preset build-release@kbh
+```
+The build output is placed in the `build/release@kbh` subfolder of the project
+The output can be installed with:
+```shell
+DESTDIR=$(pwd)/stagingdir cmake --install .
+```
+The environment variable `DESTDIR` is optional and can be ommited to install kleiner-brauhelfer directly into the system.
+
+## Build Manually
+```shell
+cmake -S . -B builddir -G Ninja
+cd builddir
+ninja
+```

--- a/kleiner-brauhelfer-core/CMakeLists.txt
+++ b/kleiner-brauhelfer-core/CMakeLists.txt
@@ -1,0 +1,47 @@
+# Qt6 Requirements
+find_package(Qt6 REQUIRED COMPONENTS Core Sql Xml)
+
+# Configure Auto MOC,UIC and RCC
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+# Set the version numbers for the core
+set(KBH_VER_MAJ 2)
+set(KBH_VER_MIN 9)
+set(KBH_VER_PAT 5)
+
+# Search all source files
+file(GLOB LIB_SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+)
+
+# Define the new static library
+add_library(kleiner-brauhelfer-core STATIC
+        ${LIB_SOURCES}
+)
+
+# Add the current directory as include search path
+target_include_directories(kleiner-brauhelfer-core PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+# Compile definitions
+target_compile_definitions(kleiner-brauhelfer-core PRIVATE
+        KLEINERBRAUHELFERCORE_LIBRARY_STATIC
+        VER_MAJ=${KBH_VER_MAJ}
+        VER_MIN=${KBH_VER_MIN}
+        VER_PAT=${KBH_VER_PAT}
+)
+
+# Link the QT libraries
+target_link_libraries(kleiner-brauhelfer-core PUBLIC
+        Qt6::Core
+        Qt6::Sql
+        Qt6::Xml
+)
+
+target_compile_options(kleiner-brauhelfer-core PRIVATE
+        -Wall
+)
+

--- a/kleiner-brauhelfer-core/CMakeLists.txt
+++ b/kleiner-brauhelfer-core/CMakeLists.txt
@@ -1,47 +1,77 @@
-# Qt6 Requirements
-find_package(Qt6 REQUIRED COMPONENTS Core Sql Xml)
+cmake_minimum_required(VERSION 3.16)
 
-# Configure Auto MOC,UIC and RCC
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
-set(CMAKE_AUTORCC ON)
+# Define project organization, name, version and build type of the library
+set(ORGANIZATION kleiner-brauhelfer)
+set(TARGET kleiner-brauhelfer-core)
+set(VERSION 2.9.5)
+set(BUILD_TYPE STATIC)
 
-# Set the version numbers for the core
-set(KBH_VER_MAJ 2)
-set(KBH_VER_MIN 9)
-set(KBH_VER_PAT 5)
+# Set name, version and language of the project
+project(${TARGET} VERSION ${VERSION} LANGUAGES CXX)
 
-# Search all source files
-file(GLOB LIB_SOURCES
-        ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+# Qt6 requirements
+find_package(Qt6 REQUIRED COMPONENTS
+    Core
+    Sql
+    Xml
 )
 
-# Define the new static library
-add_library(kleiner-brauhelfer-core STATIC
-        ${LIB_SOURCES}
+# Setup project-wide defaults to a standard arrangement
+qt_standard_project_setup(REQUIRES 6.5)
+
+# Globally disable static linkage for Qt6
+set(Qt6_STATIC OFF CACHE BOOL "" FORCE)
+
+# Set required C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Enables building multi-ABI packages for Android
+set(QT_ANDROID_BUILD_ALL_ABIS TRUE)
+
+# Source files
+file(GLOB SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
 )
 
-# Add the current directory as include search path
-target_include_directories(kleiner-brauhelfer-core PUBLIC
-        ${CMAKE_CURRENT_SOURCE_DIR}
+# Header files
+file(GLOB HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.h
 )
 
-# Compile definitions
-target_compile_definitions(kleiner-brauhelfer-core PRIVATE
-        KLEINERBRAUHELFERCORE_LIBRARY_STATIC
-        VER_MAJ=${KBH_VER_MAJ}
-        VER_MIN=${KBH_VER_MIN}
-        VER_PAT=${KBH_VER_PAT}
+# Add the library to the build system
+qt_add_library(${PROJECT_NAME} ${BUILD_TYPE}
+    ${SOURCES}
+    ${HEADERS}
 )
 
-# Link the QT libraries
-target_link_libraries(kleiner-brauhelfer-core PUBLIC
-        Qt6::Core
-        Qt6::Sql
-        Qt6::Xml
+# Add directories to the include search path
+target_include_directories(${PROJECT_NAME} PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_compile_options(kleiner-brauhelfer-core PRIVATE
-        -Wall
+# Set the definitions
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+    ORGANIZATION="${ORGANIZATION}"
+    TARGET="${TARGET}"
+    VER_MAJ=${PROJECT_VERSION_MAJOR}
+    VER_MIN=${PROJECT_VERSION_MINOR}
+    VER_PAT=${PROJECT_VERSION_PATCH}
+    VERSION="${PROJECT_VERSION}"
 )
 
+# Set the definition of the library build type
+if(${BUILD_TYPE} STREQUAL STATIC)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE KLEINERBRAUHELFERCORE_LIBRARY_STATIC)
+elseif(${BUILD_TYPE} STREQUAL SHARED)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE KLEINERBRAUHELFERCORE_LIBRARY_SHARED)
+else()
+    message(FATAL_ERROR "BUILD_TYPE must be either STATIC or SHARED" )
+endif()
+
+# Link the Qt libraries
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    Qt6::Core
+    Qt6::Sql
+    Qt6::Xml
+)

--- a/kleiner-brauhelfer-core/kleiner-brauhelfer-core.pro
+++ b/kleiner-brauhelfer-core/kleiner-brauhelfer-core.pro
@@ -28,11 +28,7 @@ CONFIG += c++11
 DEFINES += QT_DEPRECATED_WARNINGS
 CONFIG += warn_on
 
-!android: DESTDIR = $$OUT_PWD/../bin
-OBJECTS_DIR = tmp
-MOC_DIR = tmp
-UI_DIR = tmp
-RCC_DIR = tmp
+!android: DESTDIR = $$OUT_PWD/..
 
 SOURCES += \
     biercalc.cpp \

--- a/kleiner-brauhelfer/CMakeLists.txt
+++ b/kleiner-brauhelfer/CMakeLists.txt
@@ -1,0 +1,82 @@
+# Qt6 Requirements
+find_package(Qt6 REQUIRED COMPONENTS Core Sql Gui Widgets SvgWidgets Xml PrintSupport Network WebEngineWidgets LinguistTools)
+#qt_standard_project_setup()
+
+# Configure Auto MOC,UIC and RCC
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTORCC ON)
+
+# Set the version numbers
+set(KBH_VER_MAJ 2)
+set(KBH_VER_MIN 6)
+set(KBH_VER_PAT 3)
+
+set(ORGANIZATION kleiner-brauhelfer)
+set(TARGET kleiner-brauhelfer-2)
+
+# Search all source files
+file(GLOB_RECURSE EXEC_SOURCES
+        *.cpp
+        *.ui
+        *.qrc
+)
+# Search all translation files
+file(GLOB_RECURSE EXEC_TRANSLATIONS
+    *.ts
+)
+
+# Add the target
+add_executable(kleiner-brauhelfer
+        ${EXEC_SOURCES}
+)
+
+# Add the named directories as include search paths
+target_include_directories(kleiner-brauhelfer PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/headers
+        ${CMAKE_CURRENT_SOURCE_DIR}/dialogs
+        ${CMAKE_CURRENT_SOURCE_DIR}/model
+        ${CMAKE_CURRENT_SOURCE_DIR}/helper
+        ${CMAKE_CURRENT_SOURCE_DIR}/widgets
+)
+
+# Link the core library and QT
+target_link_libraries(kleiner-brauhelfer PRIVATE
+        kleiner-brauhelfer-core
+        Qt6::Core
+        Qt6::Sql
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::SvgWidgets
+        Qt6::Xml
+        Qt6::PrintSupport
+        Qt6::Network
+        Qt6::WebEngineWidgets
+)
+
+# Compile Definitions
+target_compile_definitions(kleiner-brauhelfer PRIVATE
+        VER_MAJ="${KBH_VER_MAJ}"
+        VER_MIN="${KBH_VER_MIN}"
+        VER_PAT="${KBH_VER_PAT}"
+        ORGANIZATION="${ORGANIZATION}"
+        TARGET="${TARGET}"
+        VERSION="${KBH_VER_MAJ}.${KBH_VERS_MIN}.${KBH_VER_PAT}"
+)
+
+# Add and build translations
+qt_add_translation(qmFiles ${EXEC_TRANSLATIONS})
+
+# Deployment/Installation
+install(TARGETS kleiner-brauhelfer
+    BUNDLE DESTINATION .
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
+
+qt_generate_deploy_app_script(
+        TARGET kleiner-brauhelfer
+        OUTPUT_SCRIPT deploy_script
+        NO_UNSUPPORTED_PLATFORM_ERROR
+)
+install(SCRIPT ${deploy_script})

--- a/kleiner-brauhelfer/CMakeLists.txt
+++ b/kleiner-brauhelfer/CMakeLists.txt
@@ -1,82 +1,117 @@
-# Qt6 Requirements
-find_package(Qt6 REQUIRED COMPONENTS Core Sql Gui Widgets SvgWidgets Xml PrintSupport Network WebEngineWidgets LinguistTools)
-#qt_standard_project_setup()
+cmake_minimum_required(VERSION 3.16)
 
-# Configure Auto MOC,UIC and RCC
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTOUIC ON)
-set(CMAKE_AUTORCC ON)
-
-# Set the version numbers
-set(KBH_VER_MAJ 2)
-set(KBH_VER_MIN 6)
-set(KBH_VER_PAT 3)
-
+# Define project organization, name, version and build type of the kleiner-brauhelfer-core library
 set(ORGANIZATION kleiner-brauhelfer)
 set(TARGET kleiner-brauhelfer-2)
+set(VERSION 2.9.2)
+set(BUILD_TYPE STATIC)
 
-# Search all source files
-file(GLOB_RECURSE EXEC_SOURCES
-        *.cpp
-        *.ui
-        *.qrc
+# Set name, version and language of the project
+project(${TARGET} VERSION ${VERSION} LANGUAGES CXX)
+
+# Qt6 requirements
+find_package(Qt6 REQUIRED COMPONENTS
+    Core
+    Sql
+    Gui
+    Widgets
+    SvgWidgets
+    Xml
+    PrintSupport
+    Network
+    WebEngineWidgets
+    LinguistTools
 )
+
+# Setup project-wide defaults to a standard arrangement
+qt_standard_project_setup(REQUIRES 6.5)
+
+# Globally disable static linkage for Qt6
+set(Qt6_STATIC OFF CACHE BOOL "" FORCE)
+
+# Set required C++ standard
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Handle rcc automatically for Qt targets
+set(CMAKE_AUTORCC ON)
+
+# Source files
+file(GLOB_RECURSE SOURCES
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.ui
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.qrc
+)
+
+# Header files
+file(GLOB_RECURSE HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/*.h
+)
+
 # Search all translation files
-file(GLOB_RECURSE EXEC_TRANSLATIONS
-    *.ts
+file(GLOB TRANSLATIONS
+    ${CMAKE_CURRENT_SOURCE_DIR}/translations/*.ts
 )
 
-# Add the target
-add_executable(kleiner-brauhelfer
-        ${EXEC_SOURCES}
+# Add the target to the build system
+qt_add_executable(${PROJECT_NAME}
+    ${SOURCES}
+    ${HEADERS}
 )
 
-# Add the named directories as include search paths
-target_include_directories(kleiner-brauhelfer PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CMAKE_CURRENT_SOURCE_DIR}/headers
-        ${CMAKE_CURRENT_SOURCE_DIR}/dialogs
-        ${CMAKE_CURRENT_SOURCE_DIR}/model
-        ${CMAKE_CURRENT_SOURCE_DIR}/helper
-        ${CMAKE_CURRENT_SOURCE_DIR}/widgets
+# Add directories to the include search path
+target_include_directories(${PROJECT_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/headers
+    ${CMAKE_CURRENT_SOURCE_DIR}/dialogs
+    ${CMAKE_CURRENT_SOURCE_DIR}/model
+    ${CMAKE_CURRENT_SOURCE_DIR}/helper
+    ${CMAKE_CURRENT_SOURCE_DIR}/widgets
 )
 
-# Link the core library and QT
-target_link_libraries(kleiner-brauhelfer PRIVATE
-        kleiner-brauhelfer-core
-        Qt6::Core
-        Qt6::Sql
-        Qt6::Gui
-        Qt6::Widgets
-        Qt6::SvgWidgets
-        Qt6::Xml
-        Qt6::PrintSupport
-        Qt6::Network
-        Qt6::WebEngineWidgets
+# Set the definitions
+target_compile_definitions(${PROJECT_NAME} PRIVATE
+    ORGANIZATION="${ORGANIZATION}"
+    TARGET="${TARGET}"
+    VER_MAJ=${PROJECT_VERSION_MAJOR}
+    VER_MIN=${PROJECT_VERSION_MINOR}
+    VER_PAT=${PROJECT_VERSION_PATCH}
+    VERSION="${PROJECT_VERSION}"
 )
 
-# Compile Definitions
-target_compile_definitions(kleiner-brauhelfer PRIVATE
-        VER_MAJ="${KBH_VER_MAJ}"
-        VER_MIN="${KBH_VER_MIN}"
-        VER_PAT="${KBH_VER_PAT}"
-        ORGANIZATION="${ORGANIZATION}"
-        TARGET="${TARGET}"
-        VERSION="${KBH_VER_MAJ}.${KBH_VERS_MIN}.${KBH_VER_PAT}"
+# Set the definition of the kleiner-brauhelfer-core library build type
+if(${BUILD_TYPE} STREQUAL STATIC)
+    target_compile_definitions(${PROJECT_NAME} PRIVATE KLEINERBRAUHELFERCORE_LIBRARY_STATIC)
+elseif(${BUILD_TYPE} STREQUAL SHARED)
+else()
+    message(FATAL_ERROR "BUILD_TYPE must be either STATIC or SHARED" )
+endif()
+
+# Link the core and Qt libraries
+target_link_libraries(${PROJECT_NAME} PRIVATE
+    kleiner-brauhelfer-core
+    Qt6::Core
+    Qt6::Sql
+    Qt6::Gui
+    Qt6::Widgets
+    Qt6::SvgWidgets
+    Qt6::Xml
+    Qt6::PrintSupport
+    Qt6::Network
+    Qt6::WebEngineWidgets
 )
 
 # Add and build translations
-qt_add_translation(qmFiles ${EXEC_TRANSLATIONS})
+qt_add_translation(${PROJECT_NAME} ${TRANSLATIONS})
 
-# Deployment/Installation
-install(TARGETS kleiner-brauhelfer
+# Deployment and installation
+install(TARGETS ${PROJECT_NAME}
     BUNDLE DESTINATION .
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
-
 qt_generate_deploy_app_script(
-        TARGET kleiner-brauhelfer
-        OUTPUT_SCRIPT deploy_script
-        NO_UNSUPPORTED_PLATFORM_ERROR
+    TARGET ${PROJECT_NAME}
+    OUTPUT_SCRIPT deploy_script
+    NO_UNSUPPORTED_PLATFORM_ERROR
 )
 install(SCRIPT ${deploy_script})

--- a/kleiner-brauhelfer/kleiner-brauhelfer.pro
+++ b/kleiner-brauhelfer/kleiner-brauhelfer.pro
@@ -24,18 +24,14 @@ CONFIG += c++11
 DEFINES += QT_DEPRECATED_WARNINGS
 CONFIG += warn_on
 
-DESTDIR = $$OUT_PWD/../bin
-OBJECTS_DIR = tmp
-MOC_DIR = tmp
-UI_DIR = tmp
-RCC_DIR = tmp
+DESTDIR = $$OUT_PWD/..
 
-LIBS += -L$$OUT_PWD/../bin/ -lkleiner-brauhelfer-core
+LIBS += -L$$OUT_PWD/../ -lkleiner-brauhelfer-core
 INCLUDEPATH += $$PWD/../kleiner-brauhelfer-core
 DEPENDPATH += $$PWD/../kleiner-brauhelfer-core
 DEFINES += KLEINERBRAUHELFERCORE_LIBRARY_STATIC
-win32: PRE_TARGETDEPS += $$OUT_PWD/../bin/kleiner-brauhelfer-core.lib
-unix: PRE_TARGETDEPS += $$OUT_PWD/../bin/libkleiner-brauhelfer-core.a
+win32: PRE_TARGETDEPS += $$OUT_PWD/../kleiner-brauhelfer-core.lib
+unix: PRE_TARGETDEPS += $$OUT_PWD/../libkleiner-brauhelfer-core.a
 
 SOURCES += \
     main.cpp \


### PR DESCRIPTION
Since I lastly ran into some build issues on Arch linux I had to dive a bit deeper into kbh's build system. Hence it is still qmake and the trend seems to go to CMake (even Qt6 itself is not build with qmake anymore) in my opinion will be a good choice to offer or switch to CMake.

This pull request adds the necessary files to mimick the existing qmake based system. Mabye some minor tweaks are necessary as I didn't understand the version defiinition system in-detail.

There is a presets file placed to build kbh wiht only a few cmake commands. This offers easy integration into different OS'' deployment systems. With the DESTDIR argument (described in the readme for cmake) a staging dir for packaging can be used.

If i find some time I maybe try to build a docker container with all build requirements, so host-independant builds are possible. Maybe this container can ship a cross compiler for the Windows build.


**Important Note:** With this pull request the original qmake based build system was left unmodified.