### PR TITLE
Filter auf Sud-Kategorie kann jetzt zurückgesetzt werden

### DIFF
--- a/kleiner-brauhelfer/settings.cpp
+++ b/kleiner-brauhelfer/settings.cpp
@@ -72,11 +72,11 @@ void Settings::initTheme()
         colorErrorText = QColor(180, 10, 10);
         colorErrorBase = QColor(252, 171, 171);
         colorErrorWindow = QColor(245, 185, 185);
-        colorErrorButton = QColor(230, 135, 135);
+        colorErrorButton = QColor(245, 185, 185); //QColor(230, 135, 135);
 
         colorChangedBase = QColor(255, 240, 175);
         colorChangedWindow = QColor(250, 235, 190);
-        colorChangedButton = QColor(240, 215, 140);
+        colorChangedButton = QColor(250, 235, 190); //QColor(240, 215, 140);
 
         colorMalz = QColor(248, 242, 210);
         colorHopfen = QColor(232, 248, 225);
@@ -142,11 +142,11 @@ void Settings::initTheme()
         colorErrorText = QColor(220, 80, 80);
         colorErrorBase = QColor(80, 30, 30);
         colorErrorWindow = QColor(160, 70, 70);
-        colorErrorButton = QColor(110, 45, 45);
+        colorErrorButton = QColor(160, 70, 70); //QColor(110, 45, 45);
 
         colorChangedBase = QColor(70, 65, 40);
         colorChangedWindow = QColor(85, 80, 50);
-        colorChangedButton = QColor(110, 102, 65);
+        colorChangedButton = QColor(85, 80, 50); //QColor(110, 102, 65);
 
         colorMalz = QColor(55, 52, 40);
         colorHopfen = QColor(45, 60, 50);

--- a/kleiner-brauhelfer/widgets/filterbuttonlager.cpp
+++ b/kleiner-brauhelfer/widgets/filterbuttonlager.cpp
@@ -19,7 +19,6 @@ FilterButtonLager::FilterButtonLager(QWidget *parent) :
     mRadioButtonInGebrauch(nullptr)
 {
     setCheckable(true);
-    setProperty("filterHighlight", true);
 
     QWidget* widget = new QWidget(this);
     widget->setLayout(new QVBoxLayout(widget));
@@ -77,11 +76,10 @@ void FilterButtonLager::clear()
 
 void FilterButtonLager::mousePressEvent(QMouseEvent *event)
 {
-    if (event && event->button() == Qt::RightButton)
+    if (event->button() != Qt::LeftButton)
     {
         clear();
         event->accept();
-        return;
     }
     ToolButton::mousePressEvent(event);
 }
@@ -115,7 +113,5 @@ void FilterButtonLager::updateChecked()
 {
     if (!mModel)
         return;
-    setProperty("filterHighlightActive", mModel->filter() != ProxyModelRohstoff::Alle);
-    updatePalette();
     setChecked(mModel->filter() != ProxyModelRohstoff::Alle);
 }

--- a/kleiner-brauhelfer/widgets/filterbuttonlager.cpp
+++ b/kleiner-brauhelfer/widgets/filterbuttonlager.cpp
@@ -19,6 +19,7 @@ FilterButtonLager::FilterButtonLager(QWidget *parent) :
     mRadioButtonInGebrauch(nullptr)
 {
     setCheckable(true);
+    setProperty("filterHighlight", true);
 
     QWidget* widget = new QWidget(this);
     widget->setLayout(new QVBoxLayout(widget));
@@ -71,6 +72,18 @@ void FilterButtonLager::setModel(ProxyModelRohstoff* model)
 void FilterButtonLager::clear()
 {
     mModel->clearFilter();
+    updateChecked();
+}
+
+void FilterButtonLager::mousePressEvent(QMouseEvent *event)
+{
+    if (event && event->button() == Qt::RightButton)
+    {
+        clear();
+        event->accept();
+        return;
+    }
+    ToolButton::mousePressEvent(event);
 }
 
 void FilterButtonLager::filterChanged()
@@ -102,5 +115,7 @@ void FilterButtonLager::updateChecked()
 {
     if (!mModel)
         return;
+    setProperty("filterHighlightActive", mModel->filter() != ProxyModelRohstoff::Alle);
+    updatePalette();
     setChecked(mModel->filter() != ProxyModelRohstoff::Alle);
 }

--- a/kleiner-brauhelfer/widgets/filterbuttonlager.h
+++ b/kleiner-brauhelfer/widgets/filterbuttonlager.h
@@ -3,6 +3,7 @@
 
 #include "toolbutton.h"
 #include "settings.h"
+#include <QMouseEvent>
 
 class ProxyModelRohstoff;
 class RadioButton;
@@ -26,6 +27,7 @@ private slots:
 
 private:
     void updateChecked();
+    void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
 
 private:
     ProxyModelRohstoff* mModel;

--- a/kleiner-brauhelfer/widgets/filterbuttonsud.cpp
+++ b/kleiner-brauhelfer/widgets/filterbuttonsud.cpp
@@ -17,8 +17,6 @@
 extern Brauhelfer* bh;
 extern Settings* gSettings;
 
-static const QString kFilterAllPlaceholder = QStringLiteral("*");
-
 FilterButtonSud::FilterButtonSud(QWidget *parent) :
     ToolButton(parent),
     mModel(nullptr),
@@ -111,9 +109,10 @@ void FilterButtonSud::setModel(ProxyModelSud* model, Items items)
     }
     if (items.testFlag(Item::Kategorie))
     {
+        const QString filterAllText = tr("Alle");
         layout->addWidget(new QLabel(tr("Kategorie"), widget), layout->rowCount(), 0);
         mComboBoxKategorie = new ComboBox(this);
-        mComboBoxKategorie->addItem(kFilterAllPlaceholder);
+        mComboBoxKategorie->addItem(filterAllText);
         for (int i = 0; i < bh->modelKategorien()->rowCount(); i++)
             mComboBoxKategorie->addItem(bh->modelKategorien()->data(i, ModelKategorien::ColName).toString());
         layout->addWidget(mComboBoxKategorie, layout->rowCount()-1, 1);
@@ -127,9 +126,10 @@ void FilterButtonSud::setModel(ProxyModelSud* model, Items items)
     }
     if (items.testFlag(Item::Anlage))
     {
+        const QString filterAllText = tr("Alle");
         layout->addWidget(new QLabel(tr("Anlage"), widget), layout->rowCount(), 0);
         mComboBoxAnlage = new ComboBox(this);
-        mComboBoxAnlage->addItem(kFilterAllPlaceholder);
+        mComboBoxAnlage->addItem(filterAllText);
         for (int i = 0; i < bh->modelAusruestung()->rowCount(); i++)
             mComboBoxAnlage->addItem(bh->modelAusruestung()->data(i, ModelAusruestung::ColName).toString());
         layout->addWidget(mComboBoxAnlage, layout->rowCount()-1, 1);
@@ -230,13 +230,13 @@ void FilterButtonSud::setMerkliste(bool value)
 
 void FilterButtonSud::setKategorie(const QString& value)
 {
-    mModel->setFilterKategorie(value == kFilterAllPlaceholder ? QString() : value);
+    mModel->setFilterKategorie(value == tr("Alle") ? QString() : value);
     updateChecked();
 }
 
 void FilterButtonSud::setAnlage(const QString& value)
 {
-    mModel->setFilterAnlage(value == kFilterAllPlaceholder ? QString() : value);
+    mModel->setFilterAnlage(value == tr("Alle") ? QString() : value);
     updateChecked();
 }
 
@@ -282,9 +282,9 @@ void FilterButtonSud::updateWidgets()
     if (mCheckBoxMerkliste)
         mCheckBoxMerkliste->setChecked(mModel->filterMerkliste());
     if (mComboBoxKategorie)
-        mComboBoxKategorie->setCurrentText(mModel->filterKategorie().isEmpty() ? kFilterAllPlaceholder : mModel->filterKategorie());
+        mComboBoxKategorie->setCurrentText(mModel->filterKategorie().isEmpty() ? tr("Alle") : mModel->filterKategorie());
     if (mComboBoxAnlage)
-        mComboBoxAnlage->setCurrentText(mModel->filterAnlage().isEmpty() ? kFilterAllPlaceholder : mModel->filterAnlage());
+        mComboBoxAnlage->setCurrentText(mModel->filterAnlage().isEmpty() ? tr("Alle") : mModel->filterAnlage());
     if (mCheckBoxDatum)
         mCheckBoxDatum->setChecked(mModel->filterDate());
     if (mDateEditMin)

--- a/kleiner-brauhelfer/widgets/filterbuttonsud.cpp
+++ b/kleiner-brauhelfer/widgets/filterbuttonsud.cpp
@@ -4,13 +4,11 @@
 #include <QLabel>
 #include <QWidgetAction>
 #include <QMenu>
-#include <QMouseEvent>
 #include "proxymodelsud.h"
-#include "modelkategorien.h"
-#include "modelausruestung.h"
 #include "checkbox.h"
 #include "combobox.h"
 #include "dateedit.h"
+#include "pushbutton.h"
 #include "brauhelfer.h"
 #include "settings.h"
 
@@ -30,10 +28,10 @@ FilterButtonSud::FilterButtonSud(QWidget *parent) :
     mComboBoxAnlage(nullptr),
     mCheckBoxDatum(nullptr),
     mDateEditMin(nullptr),
-    mDateEditMax(nullptr)
+    mDateEditMax(nullptr),
+    mButtonClear(nullptr)
 {
     setCheckable(true);
-    setProperty("filterHighlight", true);
 }
 
 ProxyModelSud* FilterButtonSud::model() const
@@ -84,15 +82,15 @@ void FilterButtonSud::setModel(ProxyModelSud* model, Items items)
         mCheckBoxAusgetrunken->setDefaultPalette(pal);
         layout->addWidget(mCheckBoxAusgetrunken, layout->rowCount(), 1);
         connect(mCheckBoxAusgetrunken, &QAbstractButton::clicked, this, &FilterButtonSud::setStatus);
+    }
+    if (items.testFlag(Item::Merkliste))
+    {
         line = new QFrame(this);
         line->setFrameShape(QFrame::HLine);
         line->setFrameShadow(QFrame::Sunken);
         line->setLineWidth(0);
         line->setMidLineWidth(1);
         layout->addWidget(line, layout->rowCount(), 0, 1, 2);
-    }
-    if (items.testFlag(Item::Merkliste))
-    {
         QPalette pal = palette();
         layout->addWidget(new QLabel(tr("Merkliste"), widget), layout->rowCount(), 0);
         mCheckBoxMerkliste = new CheckBox("", widget);
@@ -100,49 +98,51 @@ void FilterButtonSud::setModel(ProxyModelSud* model, Items items)
         mCheckBoxMerkliste->setDefaultPalette(pal);
         layout->addWidget(mCheckBoxMerkliste, layout->rowCount()-1, 1);
         connect(mCheckBoxMerkliste, &QAbstractButton::clicked, this, &FilterButtonSud::setMerkliste);
-        line = new QFrame(this);
-        line->setFrameShape(QFrame::HLine);
-        line->setFrameShadow(QFrame::Sunken);
-        line->setLineWidth(0);
-        line->setMidLineWidth(1);
-        layout->addWidget(line, layout->rowCount(), 0, 1, 2);
     }
     if (items.testFlag(Item::Kategorie))
     {
-        const QString filterAllText = tr("Alle");
-        layout->addWidget(new QLabel(tr("Kategorie"), widget), layout->rowCount(), 0);
-        mComboBoxKategorie = new ComboBox(this);
-        mComboBoxKategorie->addItem(filterAllText);
-        for (int i = 0; i < bh->modelKategorien()->rowCount(); i++)
-            mComboBoxKategorie->addItem(bh->modelKategorien()->data(i, ModelKategorien::ColName).toString());
-        layout->addWidget(mComboBoxKategorie, layout->rowCount()-1, 1);
-        connect(mComboBoxKategorie, &QComboBox::currentTextChanged, this, &FilterButtonSud::setKategorie);
         line = new QFrame(this);
         line->setFrameShape(QFrame::HLine);
         line->setFrameShadow(QFrame::Sunken);
         line->setLineWidth(0);
         line->setMidLineWidth(1);
         layout->addWidget(line, layout->rowCount(), 0, 1, 2);
+        layout->addWidget(new QLabel(tr("Kategorie"), widget), layout->rowCount(), 0);
+        mComboBoxKategorie = new ComboBox(this);
+        mComboBoxKategorie->addItem(tr("Alle"));
+        for (int i = 0; i < bh->modelKategorien()->rowCount(); i++)
+        {
+            QString value = bh->modelKategorien()->data(i, ModelKategorien::ColName).toString();
+            if (!value.isEmpty())
+                mComboBoxKategorie->addItem(value);
+        }
+        layout->addWidget(mComboBoxKategorie, layout->rowCount()-1, 1);
+        connect(mComboBoxKategorie, &QComboBox::currentTextChanged, this, &FilterButtonSud::setKategorie);
     }
     if (items.testFlag(Item::Anlage))
     {
-        const QString filterAllText = tr("Alle");
+        line = new QFrame(this);
+        line->setFrameShape(QFrame::HLine);
+        line->setFrameShadow(QFrame::Sunken);
+        line->setLineWidth(0);
+        line->setMidLineWidth(1);
+        layout->addWidget(line, layout->rowCount(), 0, 1, 2);
         layout->addWidget(new QLabel(tr("Anlage"), widget), layout->rowCount(), 0);
         mComboBoxAnlage = new ComboBox(this);
-        mComboBoxAnlage->addItem(filterAllText);
+        mComboBoxAnlage->addItem(tr("Alle"));
         for (int i = 0; i < bh->modelAusruestung()->rowCount(); i++)
             mComboBoxAnlage->addItem(bh->modelAusruestung()->data(i, ModelAusruestung::ColName).toString());
         layout->addWidget(mComboBoxAnlage, layout->rowCount()-1, 1);
         connect(mComboBoxAnlage, &QComboBox::currentTextChanged, this, &FilterButtonSud::setAnlage);
+    }
+    if (items.testFlag(Item::Braudatum))
+    {
         line = new QFrame(this);
         line->setFrameShape(QFrame::HLine);
         line->setFrameShadow(QFrame::Sunken);
         line->setLineWidth(0);
         line->setMidLineWidth(1);
         layout->addWidget(line, layout->rowCount(), 0, 1, 2);
-    }
-    if (items.testFlag(Item::Braudatum))
-    {
         layout->addWidget(new QLabel(tr("Gebraut"), widget), layout->rowCount(), 0);
         mCheckBoxDatum = new CheckBox(tr("zwischen"), widget);
         layout->addWidget(mCheckBoxDatum, layout->rowCount()-1, 1);
@@ -154,6 +154,18 @@ void FilterButtonSud::setModel(ProxyModelSud* model, Items items)
         mDateEditMax = new DateEdit(widget);
         layout->addWidget(mDateEditMax, layout->rowCount(), 1);
         connect(mDateEditMax, &QDateEdit::dateChanged, this, &FilterButtonSud::setMaxdate);
+    }
+    if (items.testFlag(Item::Clear))
+    {
+        line = new QFrame(this);
+        line->setFrameShape(QFrame::HLine);
+        line->setFrameShadow(QFrame::Sunken);
+        line->setLineWidth(0);
+        line->setMidLineWidth(1);
+        layout->addWidget(line, layout->rowCount(), 0, 1, 2);
+        mButtonClear = new PushButton(tr("Zurücksetzen"), widget);
+        layout->addWidget(mButtonClear, layout->rowCount(), 0, 1, 2);
+        connect(mButtonClear, &QAbstractButton::clicked, this, &FilterButtonSud::clear);
     }
 
     updateWidgets();
@@ -167,11 +179,10 @@ void FilterButtonSud::clear()
 
 void FilterButtonSud::mousePressEvent(QMouseEvent *event)
 {
-    if (event && event->button() == Qt::RightButton)
+    if (event->button() != Qt::LeftButton)
     {
         clear();
         event->accept();
-        return;
     }
     ToolButton::mousePressEvent(event);
 }
@@ -311,7 +322,5 @@ void FilterButtonSud::updateChecked()
         checked = true;
     if (!checked && mModel->filterDate())
         checked = true;
-    setProperty("filterHighlightActive", checked);
-    updatePalette();
     setChecked(checked);
 }

--- a/kleiner-brauhelfer/widgets/filterbuttonsud.cpp
+++ b/kleiner-brauhelfer/widgets/filterbuttonsud.cpp
@@ -4,7 +4,10 @@
 #include <QLabel>
 #include <QWidgetAction>
 #include <QMenu>
+#include <QMouseEvent>
 #include "proxymodelsud.h"
+#include "modelkategorien.h"
+#include "modelausruestung.h"
 #include "checkbox.h"
 #include "combobox.h"
 #include "dateedit.h"
@@ -13,6 +16,8 @@
 
 extern Brauhelfer* bh;
 extern Settings* gSettings;
+
+static const QString kFilterAllPlaceholder = QStringLiteral("*");
 
 FilterButtonSud::FilterButtonSud(QWidget *parent) :
     ToolButton(parent),
@@ -30,6 +35,7 @@ FilterButtonSud::FilterButtonSud(QWidget *parent) :
     mDateEditMax(nullptr)
 {
     setCheckable(true);
+    setProperty("filterHighlight", true);
 }
 
 ProxyModelSud* FilterButtonSud::model() const
@@ -107,10 +113,9 @@ void FilterButtonSud::setModel(ProxyModelSud* model, Items items)
     {
         layout->addWidget(new QLabel(tr("Kategorie"), widget), layout->rowCount(), 0);
         mComboBoxKategorie = new ComboBox(this);
-        ProxyModel* proxy = new ProxyModel(this);
-        proxy->setSourceModel(bh->modelKategorien());
-        mComboBoxKategorie->setModel(proxy);
-        mComboBoxKategorie->setModelColumn(ModelKategorien::ColName);
+        mComboBoxKategorie->addItem(kFilterAllPlaceholder);
+        for (int i = 0; i < bh->modelKategorien()->rowCount(); i++)
+            mComboBoxKategorie->addItem(bh->modelKategorien()->data(i, ModelKategorien::ColName).toString());
         layout->addWidget(mComboBoxKategorie, layout->rowCount()-1, 1);
         connect(mComboBoxKategorie, &QComboBox::currentTextChanged, this, &FilterButtonSud::setKategorie);
         line = new QFrame(this);
@@ -124,7 +129,7 @@ void FilterButtonSud::setModel(ProxyModelSud* model, Items items)
     {
         layout->addWidget(new QLabel(tr("Anlage"), widget), layout->rowCount(), 0);
         mComboBoxAnlage = new ComboBox(this);
-        mComboBoxAnlage->addItem("");
+        mComboBoxAnlage->addItem(kFilterAllPlaceholder);
         for (int i = 0; i < bh->modelAusruestung()->rowCount(); i++)
             mComboBoxAnlage->addItem(bh->modelAusruestung()->data(i, ModelAusruestung::ColName).toString());
         layout->addWidget(mComboBoxAnlage, layout->rowCount()-1, 1);
@@ -157,6 +162,18 @@ void FilterButtonSud::setModel(ProxyModelSud* model, Items items)
 void FilterButtonSud::clear()
 {
     mModel->clearFilter();
+    updateWidgets();
+}
+
+void FilterButtonSud::mousePressEvent(QMouseEvent *event)
+{
+    if (event && event->button() == Qt::RightButton)
+    {
+        clear();
+        event->accept();
+        return;
+    }
+    ToolButton::mousePressEvent(event);
 }
 
 void FilterButtonSud::setStatusAlle(bool value)
@@ -213,13 +230,13 @@ void FilterButtonSud::setMerkliste(bool value)
 
 void FilterButtonSud::setKategorie(const QString& value)
 {
-    mModel->setFilterKategorie(value);
+    mModel->setFilterKategorie(value == kFilterAllPlaceholder ? QString() : value);
     updateChecked();
 }
 
 void FilterButtonSud::setAnlage(const QString& value)
 {
-    mModel->setFilterAnlage(value);
+    mModel->setFilterAnlage(value == kFilterAllPlaceholder ? QString() : value);
     updateChecked();
 }
 
@@ -265,9 +282,9 @@ void FilterButtonSud::updateWidgets()
     if (mCheckBoxMerkliste)
         mCheckBoxMerkliste->setChecked(mModel->filterMerkliste());
     if (mComboBoxKategorie)
-        mComboBoxKategorie->setCurrentText(mModel->filterKategorie());
+        mComboBoxKategorie->setCurrentText(mModel->filterKategorie().isEmpty() ? kFilterAllPlaceholder : mModel->filterKategorie());
     if (mComboBoxAnlage)
-        mComboBoxAnlage->setCurrentText(mModel->filterAnlage());
+        mComboBoxAnlage->setCurrentText(mModel->filterAnlage().isEmpty() ? kFilterAllPlaceholder : mModel->filterAnlage());
     if (mCheckBoxDatum)
         mCheckBoxDatum->setChecked(mModel->filterDate());
     if (mDateEditMin)
@@ -294,5 +311,7 @@ void FilterButtonSud::updateChecked()
         checked = true;
     if (!checked && mModel->filterDate())
         checked = true;
+    setProperty("filterHighlightActive", checked);
+    updatePalette();
     setChecked(checked);
 }

--- a/kleiner-brauhelfer/widgets/filterbuttonsud.h
+++ b/kleiner-brauhelfer/widgets/filterbuttonsud.h
@@ -8,6 +8,7 @@ class ProxyModelSud;
 class CheckBox;
 class ComboBox;
 class DateEdit;
+class PushButton;
 
 class FilterButtonSud : public ToolButton
 {
@@ -15,11 +16,12 @@ class FilterButtonSud : public ToolButton
 
 public:
     enum Item {
-        Status = 1,
-        Merkliste = 2,
-        Kategorie = 4,
-        Anlage = 8,
-        Braudatum = 16,
+        Clear = 1,
+        Status = 2,
+        Merkliste = 4,
+        Kategorie = 8,
+        Anlage = 16,
+        Braudatum = 32,
         Alle = 255
     };
     Q_DECLARE_FLAGS(Items, Item)
@@ -60,6 +62,7 @@ private:
     CheckBox* mCheckBoxDatum;
     DateEdit* mDateEditMin;
     DateEdit* mDateEditMax;
+    PushButton* mButtonClear;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(FilterButtonSud::Items)

--- a/kleiner-brauhelfer/widgets/filterbuttonsud.h
+++ b/kleiner-brauhelfer/widgets/filterbuttonsud.h
@@ -2,6 +2,7 @@
 #define FILTERBUTTONSUD_H
 
 #include "toolbutton.h"
+#include <QMouseEvent>
 
 class ProxyModelSud;
 class CheckBox;
@@ -44,6 +45,7 @@ private slots:
 
 private:
     void updateChecked();
+    void mousePressEvent(QMouseEvent *event) Q_DECL_OVERRIDE;
 
 private:
     ProxyModelSud* mModel;

--- a/kleiner-brauhelfer/widgets/pushbutton.cpp
+++ b/kleiner-brauhelfer/widgets/pushbutton.cpp
@@ -14,6 +14,16 @@ PushButton::PushButton(QWidget *parent) :
     connect(this, &QAbstractButton::clicked, this, &PushButton::updatePalette);
 }
 
+PushButton::PushButton(const QString &text, QWidget *parent) :
+    QPushButton(text, parent),
+    mDefaultPalette(palette()),
+    mAction(nullptr),
+    mError(false)
+{
+    setAutoDefault(false);
+    connect(this, &QAbstractButton::clicked, this, &PushButton::updatePalette);
+}
+
 void PushButton::addChangeDecorator()
 {
     connect(this, &QAbstractButton::clicked, [this](){WidgetDecorator::valueChanged(this, hasFocus());});

--- a/kleiner-brauhelfer/widgets/pushbutton.h
+++ b/kleiner-brauhelfer/widgets/pushbutton.h
@@ -9,6 +9,7 @@ class PushButton : public QPushButton
 
 public:
     explicit PushButton(QWidget *parent = nullptr);
+    explicit PushButton(const QString &text, QWidget *parent = nullptr);
     void addChangeDecorator();
     void setAction(QAction *action);
     void setDefaultPalette(const QPalette &p);

--- a/kleiner-brauhelfer/widgets/toolbutton.cpp
+++ b/kleiner-brauhelfer/widgets/toolbutton.cpp
@@ -1,36 +1,17 @@
 #include "toolbutton.h"
 #include <QGuiApplication>
-#include <QColor>
 #include "widgetdecorator.h"
 #include "settings.h"
 
 extern Settings *gSettings;
-
-static QString filterHighlightStyle()
-{
-    if (!gSettings)
-        return QString();
-
-    const QColor buttonColor = gSettings->paletteChanged.color(QPalette::Button);
-    const QColor borderColor = buttonColor.darker(125);
-    return QStringLiteral(
-        "QToolButton[filterHighlight=\"true\"][filterHighlightActive=\"true\"] {"
-        " background-color: %1;"
-        " border: 1px solid %2;"
-        " border-radius: 3px;"
-        "}"
-    ).arg(buttonColor.name(QColor::HexArgb), borderColor.name(QColor::HexArgb));
-}
 
 ToolButton::ToolButton(QWidget *parent) :
     QToolButton(parent),
     mError(false)
 {
     setPopupMode(ToolButtonPopupMode::InstantPopup);
-    setStyleSheet(filterHighlightStyle());
-    if (gSettings)
-        connect(gSettings, &Settings::themeChanged, this, [this](){ setStyleSheet(filterHighlightStyle()); updatePalette(); });
     connect(this, &QAbstractButton::clicked, this, &ToolButton::updatePalette);
+    connect(this, &QAbstractButton::toggled, this, &ToolButton::updatePalette);
 }
 
 void ToolButton::addChangeDecorator()
@@ -50,20 +31,17 @@ bool ToolButton::event(QEvent *event)
 
 void ToolButton::updatePalette()
 {
-    if (property("filterHighlight").toBool())
-        setStyleSheet(filterHighlightStyle());
-
     if (WidgetDecorator::contains(this))
     {
         if (palette() != gSettings->paletteChanged)
             setPalette(gSettings->paletteChanged);
     }
-    else if (property("filterHighlight").toBool() && property("filterHighlightActive").toBool())
-    {
-        if (palette() != gSettings->paletteChanged)
-            setPalette(gSettings->paletteChanged);
-    }
     else if (mError)
+    {
+        if (palette() != gSettings->paletteError)
+            setPalette(gSettings->paletteError);
+    }
+    else if (isChecked())
     {
         if (palette() != gSettings->paletteError)
             setPalette(gSettings->paletteError);

--- a/kleiner-brauhelfer/widgets/toolbutton.cpp
+++ b/kleiner-brauhelfer/widgets/toolbutton.cpp
@@ -1,15 +1,35 @@
 #include "toolbutton.h"
 #include <QGuiApplication>
+#include <QColor>
 #include "widgetdecorator.h"
 #include "settings.h"
 
 extern Settings *gSettings;
+
+static QString filterHighlightStyle()
+{
+    if (!gSettings)
+        return QString();
+
+    const QColor buttonColor = gSettings->paletteChanged.color(QPalette::Button);
+    const QColor borderColor = buttonColor.darker(125);
+    return QStringLiteral(
+        "QToolButton[filterHighlight=\"true\"][filterHighlightActive=\"true\"] {"
+        " background-color: %1;"
+        " border: 1px solid %2;"
+        " border-radius: 3px;"
+        "}"
+    ).arg(buttonColor.name(QColor::HexArgb), borderColor.name(QColor::HexArgb));
+}
 
 ToolButton::ToolButton(QWidget *parent) :
     QToolButton(parent),
     mError(false)
 {
     setPopupMode(ToolButtonPopupMode::InstantPopup);
+    setStyleSheet(filterHighlightStyle());
+    if (gSettings)
+        connect(gSettings, &Settings::themeChanged, this, [this](){ setStyleSheet(filterHighlightStyle()); updatePalette(); });
     connect(this, &QAbstractButton::clicked, this, &ToolButton::updatePalette);
 }
 
@@ -30,7 +50,15 @@ bool ToolButton::event(QEvent *event)
 
 void ToolButton::updatePalette()
 {
+    if (property("filterHighlight").toBool())
+        setStyleSheet(filterHighlightStyle());
+
     if (WidgetDecorator::contains(this))
+    {
+        if (palette() != gSettings->paletteChanged)
+            setPalette(gSettings->paletteChanged);
+    }
+    else if (property("filterHighlight").toBool() && property("filterHighlightActive").toBool())
     {
         if (palette() != gSettings->paletteChanged)
             setPalette(gSettings->paletteChanged);

--- a/kleiner-brauhelfer/widgets/toolbutton.h
+++ b/kleiner-brauhelfer/widgets/toolbutton.h
@@ -11,7 +11,7 @@ public:
     explicit ToolButton(QWidget *parent = nullptr);
     void addChangeDecorator();
     void setError(bool e);
-private:
+protected:
     bool event(QEvent *event) Q_DECL_OVERRIDE;
     void updatePalette();
 private:

--- a/kleiner-brauhelfer/widgets/toolbutton.h
+++ b/kleiner-brauhelfer/widgets/toolbutton.h
@@ -11,7 +11,7 @@ public:
     explicit ToolButton(QWidget *parent = nullptr);
     void addChangeDecorator();
     void setError(bool e);
-protected:
+private:
     bool event(QEvent *event) Q_DECL_OVERRIDE;
     void updatePalette();
 private:


### PR DESCRIPTION
Ich hatte mit der neuen Maske das Problem, dass wenn man eine Kategorie beim Filter in der Subauswahl ausgewählt hat, das man den Filter nicht mehr zurück auf "Alle" setzen konnte sondern nur nach einer anderen Kategorie filtern konnte.

Ich habe die Kategorie Lösung an der existierenden funktionierenden Lösung für die Auswahl des Anlagen-Filter (Ebenfalls in der Sudauswahl) orientiert.

Der Text für "Alle" bei beiden Dropdown Menüs ist jetzt "*" anstatt einfach ein leerer String. ("Alle" wäre nicht Sprachneutral"). Zusätzlich kann man jetzt alle Filter zurücksetzen indem man auf das Filter-Symbol rechts klickt. gibt es einen aktiven Filter ist das Filter Symbol außerdem gelb hinterlegt, das kleine dreieck im Symbol hatte ich einfach übersehen, so sticht ein aktiver Filter schneller ins Auge. Hab die selbe Logik auch für den filter im Lager übernommen und getestet.

<img width="202" height="413" alt="grafik" src="https://github.com/user-attachments/assets/959bf1ef-60a1-48f0-bcbb-7efb9fca46c5" />

<img width="205" height="418" alt="grafik" src="https://github.com/user-attachments/assets/c1e5144d-50b7-4267-95bd-bb590cc91a21" />

<img width="285" height="184" alt="grafik" src="https://github.com/user-attachments/assets/0eaa0412-ad39-4a7a-ba2a-7e69640362f1" />

<img width="287" height="191" alt="grafik" src="https://github.com/user-attachments/assets/706992dd-cad3-433a-96d8-659796c748ff" />
